### PR TITLE
Fetch Nix as a flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,9 +22,7 @@
     },
     "nix": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1612967703,
@@ -58,6 +56,21 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1602702596,
+        "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad0d20345219790533ebe06571f82ed6b034db31",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-20.09-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1612105129,
         "narHash": "sha256-F8vlMh3lnadePP4gcdqxGNfvP2jRqDxwZamVhPfD0Zk=",
         "owner": "nixos",
@@ -77,7 +90,7 @@
         "home-manager": "home-manager",
         "nix": "nix",
         "nixGL": "nixGL",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,26 @@
         "type": "github"
       }
     },
+    "nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1612967703,
+        "narHash": "sha256-SAKaRKKDd1jM4fgbXUze+ynaHetHOPVkVrMfkRiA5XE=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "4e98f0345c144b9d85bed1f6b0bc509bf7ddc000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixGL": {
       "flake": false,
       "locked": {
@@ -55,6 +75,7 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "nix": "nix",
         "nixGL": "nixGL",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nix.url = "github:NixOS/nix";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     nixGL ={
@@ -11,23 +12,24 @@
     };
   };
 
-  outputs = { self, nixpkgs, home-manager, ... }@inputs: 
+  outputs = { self, nixpkgs, nix, home-manager, ... }@inputs: 
   let
     system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
+    pkgsArgs = { inherit system; overlays = [nix.overlay]; };
+    pkgs = import nixpkgs pkgsArgs;
     nixGL = import inputs.nixGL {
-      pkgs = import nixpkgs { allowUnfree = true; inherit system; };
+      pkgs = import nixpkgs (pkgsArgs // { allowUnfree = true; });
     };
-    homeCfgs = (import ./home/default.nix {
-      inherit pkgs home-manager system nixGL;
+    homeCfgs = (pkgs.callPackage ./home/default.nix {
+      inherit pkgs home-manager system nixGL nix;
     });
   in {
-    defaultPackage.x86_64-linux = homeCfgs.laptop.activationPackage;
-    packages.x86_64-linux = {
+    defaultPackage.${system} = homeCfgs.laptop.activationPackage;
+    packages.${system} = {
       home-laptop = homeCfgs.laptop.activationPackage;
       home-devbox = homeCfgs.devbox.activationPackage;
     };
-    apps.x86_64-linux = {
+    apps.${system} = {
       home-laptop = {
         type = "app";
         program = "${self.packages.x86_64-linux.home-laptop}/activate";

--- a/home/common.nix
+++ b/home/common.nix
@@ -21,7 +21,7 @@
 
   home.language.base = "en_US.UTF-8";
   home.packages = with pkgs; [
-    nixUnstable
+    nixModern /* imported in ../overlays/default.nix from NixOS/nix flake */
     # Not installing mosh, because of
     # https://github.com/NixOS/nixpkgs/issues/90523
     # mosh

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,8 +1,8 @@
-{ pkgs, home-manager, system, nixGL, nix }:
+{ system, pkgs, home-manager, nixGL, nix }:
 
 let
   overlays = (pkgs.callPackage ../overlays { inherit pkgs nixGL nix; });
-  commonImports = {pkgs, ...}: [
+  commonImports = [
     overlays
     ./common.nix
   ];
@@ -12,7 +12,7 @@ in {
     homeDirectory = "/home/nk";
     username = "nk";
     configuration = {pkgs, ...}@confInputs: rec {
-      imports = (commonImports confInputs) ++ [
+      imports = commonImports ++ [
         ./laptop.nix
       ];
       home = {
@@ -25,7 +25,7 @@ in {
     homeDirectory = "/home/serge";
     username = "serge";
     configuration = {pkgs, ...}@confInputs: rec {
-      imports = (commonImports confInputs) ++ [
+      imports = commonImports ++ [
         ./devbox.nix
       ];
       home = {

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,16 +1,18 @@
-{ pkgs, home-manager, system, nixGL }:
+{ pkgs, home-manager, system, nixGL, nix }:
 
 let
-  overlays = (import ../overlays { inherit pkgs nixGL; });
+  overlays = (pkgs.callPackage ../overlays { inherit pkgs nixGL nix; });
+  commonImports = {pkgs, ...}: [
+    overlays
+    ./common.nix
+  ];
 in {
   laptop = home-manager.lib.homeManagerConfiguration rec {
     inherit system;
     homeDirectory = "/home/nk";
     username = "nk";
-    configuration = {pkgs, ...}: rec {
-      imports = [
-        overlays
-        ./common.nix
+    configuration = {pkgs, ...}@confInputs: rec {
+      imports = (commonImports confInputs) ++ [
         ./laptop.nix
       ];
       home = {
@@ -22,10 +24,8 @@ in {
     inherit system;
     homeDirectory = "/home/serge";
     username = "serge";
-    configuration = {pkgs, ...}: rec {
-      imports = [
-        overlays
-        ./common.nix
+    configuration = {pkgs, ...}@confInputs: rec {
+      imports = (commonImports confInputs) ++ [
         ./devbox.nix
       ];
       home = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,11 +1,11 @@
-{ pkgs, nixGL }:
+{ system, pkgs, nixGL, nix }:
 
 let
   addInjectGL = (final: prev: {
     inherit (nixGL) nixGLNvidia nixGLIntel nixGLDefault;
   });
-  useNixUnstable = (final: prev: {
-    nix = prev.nixUnstable;
+  useModernNix = (final: prev: {
+    inherit (nix.packages.${system}) nix;
   });
   addPythonLinters = (import ./pylinters.nix);
   overlays = {...}: {
@@ -13,6 +13,7 @@ let
       addInjectGL
       # useNixUnstable  -- this breaks cachix
       addPythonLinters
+      useModernNix
     ];
   };
 in overlays

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -5,7 +5,7 @@ let
     inherit (nixGL) nixGLNvidia nixGLIntel nixGLDefault;
   });
   useModernNix = (final: prev: {
-    inherit (nix.packages.${system}) nix;
+    nixModern = nix.packages.${system}.nix;
   });
   addPythonLinters = (import ./pylinters.nix);
   overlays = {...}: {


### PR DESCRIPTION
So we can have an up-to-date nix (with flakes support and all) independently of what's pinned in nixpkgs